### PR TITLE
Added suppress function to temporary prevent the fire function.

### DIFF
--- a/source/ouibounce.js
+++ b/source/ouibounce.js
@@ -82,7 +82,7 @@ function ouibounce(el, custom_config) {
   // You can use ouibounce without passing an element
   // https://github.com/carlsednaoui/ouibounce/issues/30
   function fire() {
-    if (isDisabled()) { return; }
+    if (isDisabled() || supressed) { return; }
 
     if (el) { el.style.display = 'block'; }
 
@@ -123,11 +123,18 @@ function ouibounce(el, custom_config) {
     _html.removeEventListener('keydown', handleKeydown);
   }
 
+  var supressed;
+  function suppress(value) {
+    supressed = value;
+  }
+
   return {
     fire: fire,
     disable: disable,
-    isDisabled: isDisabled
+    isDisabled: isDisabled,
+    suppress: suppress
   };
+
 }
 
 /*exported ouibounce */


### PR DESCRIPTION
Added suppress function. The fire function won't be executed when ouibounce is suppressed untill suppress(false) is called. 

In my case I did not want to fire function to trigger when another dialog was open on my page. However, I wanted the fire function to be triggered again once that dialog is closed.
Calling suppress(true) when opening the dialog and suppres(false) when closing this dialog does the trick now.
