### PR TITLE
control the disable ouibounce through callback

### DIFF
--- a/source/ouibounce.js
+++ b/source/ouibounce.js
@@ -86,8 +86,9 @@ function ouibounce(el, custom_config) {
 
     if (el) { el.style.display = 'block'; }
 
-    callback();
-    disable();
+    if (false !== callback()) {
+      disable();
+    }
   }
 
   function disable(custom_options) {


### PR DESCRIPTION
if callback return **false** cookie is not created. And after that we can disable popup only by pressing "No thanks" button, e.g. 
`_ouibounce.disable({ cookieExpire: 7, sitewide: true });`